### PR TITLE
Updated slim dependency to allow >=v2.4 and <v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php":       ">=5.3.0",
-        "slim/slim": "~2.4.0"
+        "slim/slim": "~2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",


### PR DESCRIPTION
Recently Slim 2.5 was published, and there is no way to use slimcontroller with it (by using composer, I mean), because it depends on slim ~2.4.0, which is >=2.4.0 and < 2.5.
I updated the composer.json file to allow versions >=2.4 and <3.0, which should work fine.

What do you think?